### PR TITLE
Two -02 follow-ups missed by PR #4: HSYNCPARAM disclaimer trim + bootstrap depth cleanup

### DIFF
--- a/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
+++ b/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
@@ -481,15 +481,15 @@ and validation of the corresponding KEY record (if supporting
 automatic bootstrap) or put that key into a queue for subsequent
 manual validation and verification.
 
-### Automatic Bootstrap of the SIG(0) Public Key
-
 Automated bootstrapping is also possible, subject to the policy of the
 UPDATE Receiver. The basic idea is to publish the public SIG(0) key as
 a KEY record either at the child apex or at a special name below the
 name of an authoritative nameserver for the zone located in a DNSSEC-
 signed zone. This publication must occur prior to the initial key
 upload. Then the UPDATE Receiver (or an agent) may look that KEY up
-for subsequent validation.
+for subsequent validation. The following three subsections describe
+the three automatic bootstrap methods this document defines, one per
+case of child-zone signing status.
 
 ### Automatic Bootstrap When Child Zone Is DNSSEC-signed
 
@@ -550,8 +550,7 @@ bootstrap as described in {{!RFC9615}}. As the proof of the SIG(0) key
 being authentic is based on a clear DNSSEC signature chain this method
 is as secure as if the child zone had been signed.
 
-#### Operator coordination via HSYNCPARAM
-
+**Operator coordination via HSYNCPARAM.**
 The KEY record at `_sig0key.{child}._signal.{nameserver}.` must be
 published by the operator of the nameserver's zone, not by the
 operator of the child zone. The child operator therefore needs a
@@ -615,7 +614,7 @@ previous methods but it is possible to make on-path attacks
 arbitrarily difficult by using a larger number of repeated queries
 from a larger number of vantage points.
 
-### Publishing Supported Bootstrap Methods
+## Publishing Supported Bootstrap Methods
 
 As there are multiple possible methods to bootstrap the initial SIG(0)
 public key to become trusted by the parent it becomes important for
@@ -628,7 +627,7 @@ at the target of the DSYNC record to announce capabilities. For the
 UPDATE Receiver the important capabilities are primarily supported
 bootstrap methods.
 
-#### SvcParamKey "bootstrap"
+### SvcParamKey "bootstrap"
 
 The "bootstrap" SvcParamKey in the SVCB record is used to signal what
 mechanisms are supported for bootstrapping the trust of the child's public
@@ -674,7 +673,7 @@ mechanisms, separated by ",". The mechanisms may occur in arbitrary order.
 
 New mechanisms are likely to be defined in the future.
 
-#### Complete Example
+### Complete Example
 
 Example for a parent that operates an UPDATE Receiver that only
 supports the secure automatic bootstrap methods "at-apex" and

--- a/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
+++ b/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
@@ -561,17 +561,14 @@ that they should publish the KEY record under the appropriate
 zone.
 
 This document recommends, but does not require, that this
-instruction be conveyed via the HSYNCPARAM record defined in
-{{?I-D.leon-dnsop-signaling-zone-owner-intent}}, using a key
-(tentatively named `pubkey`) in that record. The set of
-HSYNCPARAM keys is defined by that document and is *not* part of
-the SvcParamKey registry; the final name and IANA arrangements
-for this key are still under discussion. HSYNCPARAM is published
-in the child zone, and the providers of the child zone are
-authoritative for that zone and can therefore observe HSYNCPARAM
-directly. The `pubkey` signal expresses the child operator's
-intent that each provider SHOULD publish the child's SIG(0) KEY
-at `_sig0key.{child}._signal.{their-ns-name}.` in their own zone.
+instruction be conveyed via the `pubkey` key of the HSYNCPARAM
+record defined in {{?I-D.leon-dnsop-signaling-zone-owner-intent}}.
+HSYNCPARAM is published in the child zone, and the providers of
+the child zone are authoritative for that zone and can therefore
+observe HSYNCPARAM directly. The `pubkey` signal expresses the
+child operator's intent that each provider SHOULD publish the
+child's SIG(0) KEY at `_sig0key.{child}._signal.{their-ns-name}.`
+in their own zone.
 
 The mechanics of how each provider acts on this signal
 (operational coordination, provisioning APIs, internal handoffs,


### PR DESCRIPTION
## Summary

Two commits that landed in working state during PR #4 review but
didn't make it into the merge. Restoring them as a follow-up so
\`main\` reflects the full reviewed -02 state before the next round
of edits.

### Commit 1 (712b27c): trim §Operator coordination via HSYNCPARAM disclaimer

Drops the "not part of the SvcParamKey registry; final name and
IANA arrangements still under discussion" disclaimer. HSYNCPARAM
itself is not yet published (that draft is forthcoming), so this
draft should not make claims about the state of registries or
discussions that don't yet exist. The \`pubkey\` key is now
referenced by name directly; its definition lives in the sister
draft.

### Commit 2 (ae7b441): cut SIG(0) bootstrap section depth (max H3)

Three structural cleanups to §Management of SIG(0) Public Keys:

1. Drop the \`### Automatic Bootstrap of the SIG(0) Public Key\`
   wrapper; its single paragraph of intro becomes part of the
   parent §Bootstrapping section, with a forward-pointer to the
   three method subsections.
2. Promote \`### Publishing Supported Bootstrap Methods\` to \`##\`
   (method-advertisement is a different layer from methods);
   children demote to \`###\`.
3. Demote \`#### Operator coordination via HSYNCPARAM\` to a bold
   lead-in paragraph.

Max heading depth in the chapter is now H3 (was H4 in two places).
No content changes — pure structural cleanup.

## Test plan

- [ ] \`make\` renders cleanly
- [ ] TOC shows the new flatter structure