### PR TITLE
-02: cite alg-experimental-ranges as path to PQ-safe SIG(0) algorithm

### DIFF
--- a/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
+++ b/draft-ietf-dnsop-delegation-mgmt-via-ddns-02.md
@@ -444,6 +444,11 @@ operators are encouraged to adopt them for the SIG(0) key on this
 path: there is no operational reason to prefer a classical
 algorithm here.
 
+The experimental algorithm code-point range proposed in
+{{?I-D.johani-dnsop-dnssec-alg-experimental-ranges}} provides one
+path by which a PQ-safe algorithm can be used on this path before
+full IETF standardization completes.
+
 ## Communication Between Child and Parent UPDATE Receiver
 
 There are two cases where communication between child and parent


### PR DESCRIPTION
## Summary

The §Choice of SIG(0) Signature Algorithm section says PQ-safe
algorithms become useful "as they become standardized for DNSSEC
use." That phrasing was unspecific: today there is no path to
assign a code point to a PQ-safe algorithm short of full IETF
standardization. The companion draft alg-experimental-ranges
proposes the experimental code-point range that bridges this gap.

Adds an informative reference paragraph at the end of §Choice of
SIG(0) Signature Algorithm naming that mechanism. No other text
changes.

## Note

The cite \`?I-D.johani-dnsop-dnssec-alg-experimental-ranges\`
will render as "*** BROKEN REFERENCE ***" until that draft is
submitted to datatracker. The companion change in that draft
(adding the SIG(0) use case as a second motivating scenario) was
merged in johanix/draft-johani-dnsop-dnssec-alg-experimental-ranges#1.

## Test plan

- [ ] \`make\` renders cleanly
- [ ] Cross-reference renders as expected (broken until peer is
      submitted to datatracker)